### PR TITLE
Fix toolbar button duplication in second GtWorld window

### DIFF
--- a/src/GToolkit-Phlow/GtPhlowView.class.st
+++ b/src/GToolkit-Phlow/GtPhlowView.class.st
@@ -304,9 +304,10 @@ GtPhlowView >> actionsToolbarForElement: anElement [
 	aToolbar
 		withAsyncPromiseDo: [ :anElementPromise | 
 			anElementPromise
-				whenSuccess: [ :aToolbarElement :theActions | 
+				whenSuccess: [ :aToolbarElement :theActions |
+					aToolbar removeAllItems.
 					theActions
-						do: [ :phlowAction | 
+						do: [ :phlowAction |
 							phlowAction
 								asElement: [ :actionElement | aToolbar addItem: actionElement ]
 								withHostElement: anElement ] ].


### PR DESCRIPTION
## Summary

- Inspector toolbar buttons are duplicated when opening an inspector in a second GtWorld window (`GtWorld openDefault`)
- The `whenSuccess:` callback in `GtPhlowView>>actionsToolbarForElement:` fires multiple times during the GtWorld lifecycle (scene graph attachment race in `BrAsyncElementPromise` / `BrElementUpdater`), each time appending all action buttons
- Fix: clear toolbar items before adding (`aToolbar removeAllItems.`) to make the callback idempotent

## Steps to Reproduce

1. Open a first GtWorld (normal startup)
2. Open a second GtWorld via `GtWorld openDefault`
3. Inspect any object in the second window
4. Observe the toolbar — buttons appear twice

Fixes feenkcom/gtoolkit#5020